### PR TITLE
Don't run into infinite loop, if area is empty

### DIFF
--- a/map-fragment/reader/MapReader.js
+++ b/map-fragment/reader/MapReader.js
@@ -56,12 +56,12 @@ class MapReader {
             zIndex,
             levels
         );
-        if (!levels.has(zIndex)) {
+        if (area.rooms.length > 0 && !levels.has(zIndex)) {
             candidateArea = this.getArea(areaId, levels.values().next().value);
         }
         return candidateArea;
     }
-    
+
     getAreaProperties(areaId) {
         return this.data[this.mapDataIndex[areaId]];
     }
@@ -81,7 +81,7 @@ class MapReader {
     getRoomById(id) {
         return this.roomIndex[id];
     }
-    
+
 }
 
 module.exports = {


### PR DESCRIPTION
If an area is empty, no z coordinates are ever added to the levels set, which results in an infinite loop.