### PR TITLE
feat: cache area-based paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ fs.writeFileSync("mapFragment.svg", renderer.exportSvg(roomId, 10));
 console.log("Map generated");
 ```
 
+## Pathfinding
+
+The library includes a simple `PathFinder` that searches for routes between
+rooms. The path finder now builds route graphs on demand and caches both the
+graphs and calculated paths. When two rooms reside in the same area only that
+area's graph is used, which speeds up path calculations for large maps.
+
 ## Settings and their default values 
 ```js
 class Settings {

--- a/map-fragment/reader/PathFinder.js
+++ b/map-fragment/reader/PathFinder.js
@@ -1,26 +1,83 @@
 const { MapReader } = require("./MapReader");
-const Graph = require("node-dijkstra")
+const Graph = require("node-dijkstra");
 
 class PathFinder {
-
     /**
-     * 
-     * @param {MapReader} reader 
+     * @param {MapReader} reader
      */
     constructor(reader) {
-        this.route = new Graph();
-        reader.getAreas().forEach(area => area.rooms.forEach(room => {
-            let exits = Object.values(room.exits).concat(Object.values(room.specialExits)).map(item => [item, room.weight ?? 1]);
-            this.route.addNode(room.id.toString(), Object.fromEntries(exits))
-        }))
+        this.reader = reader;
+        this.areaGraphs = new Map();
+        this.pathCache = new Map();
     }
 
+    /**
+     * Build and cache a graph for a specific area.
+     * @param {number} areaId
+     * @returns {Graph}
+     */
+    _buildAreaGraph(areaId) {
+        const graph = new Graph();
+        const area = this.reader.getAreaProperties(areaId);
+        if (area?.rooms) {
+            area.rooms.forEach((room) => {
+                const exits = Object.values(room.exits)
+                    .concat(Object.values(room.specialExits))
+                    .map((id) => [id, room.weight ?? 1]);
+                graph.addNode(room.id.toString(), Object.fromEntries(exits));
+            });
+        }
+        this.areaGraphs.set(areaId, graph);
+        return graph;
+    }
+
+    /**
+     * Lazily build a graph for the whole map.
+     * @returns {Graph}
+     */
+    _buildGlobalGraph() {
+        const graph = new Graph();
+        this.reader.getAreas().forEach((area) =>
+            area.rooms.forEach((room) => {
+                const exits = Object.values(room.exits)
+                    .concat(Object.values(room.specialExits))
+                    .map((id) => [id, room.weight ?? 1]);
+                graph.addNode(room.id.toString(), Object.fromEntries(exits));
+            })
+        );
+        this.globalGraph = graph;
+        return graph;
+    }
+
+    /**
+     * Find a path between two rooms. Results are cached.
+     * @param {number} from
+     * @param {number} to
+     * @returns {Array<string>|null}
+     */
     path(from, to) {
-        return this.route.path(from.toString(), to.toString())
-    }
+        const cacheKey = `${from}-${to}`;
+        if (this.pathCache.has(cacheKey)) {
+            return this.pathCache.get(cacheKey);
+        }
 
+        const fromRoom = this.reader.getRoomById(from);
+        const toRoom = this.reader.getRoomById(to);
+
+        let graph;
+        if (fromRoom && toRoom && fromRoom.areaId === toRoom.areaId) {
+            const areaId = fromRoom.areaId;
+            graph = this.areaGraphs.get(areaId) ?? this._buildAreaGraph(areaId);
+        } else {
+            graph = this.globalGraph ?? this._buildGlobalGraph();
+        }
+
+        const result = graph.path(from.toString(), to.toString());
+        this.pathCache.set(cacheKey, result);
+        return result;
+    }
 }
 
 module.exports = {
-    PathFinder
-}
+    PathFinder,
+};


### PR DESCRIPTION
## Summary
- optimize pathfinding by caching per-area graphs and results
- document PathFinder behavior and caching strategy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node - <<'NODE'
const { PathFinder } = require('./map-fragment/reader/PathFinder');
const { MapReader } = require('./map-fragment/reader/MapReader');

const mapData = [{
  areaId: 1,
  areaName: 'Test',
  rooms: [
    {id: 1, exits:{2:2}, specialExits:{}, weight:1, x:0, y:0, z:0},
    {id: 2, exits:{1:1}, specialExits:{}, weight:1, x:1, y:0, z:0}
  ],
  labels: []
}];
const reader = new MapReader(mapData, []);
const pf = new PathFinder(reader);
console.log('first', pf.path(1,2));
console.log('cached', pf.path(1,2));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6891e1f67534832a81623b0523dacf60