### PR TITLE
feat: cache area-based paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ fs.writeFileSync("mapFragment.svg", renderer.exportSvg(roomId, 10));
 console.log("Map generated");
 ```
 
+## Pathfinding
+
+The library includes a simple `PathFinder` that searches for routes between
+rooms. The path finder now builds route graphs on demand and caches both the
+graphs and calculated paths. When two rooms reside in the same area only that
+area's graph is used, which speeds up path calculations for large maps.
+
 ## Settings and their default values 
 ```js
 class Settings {

--- a/map-fragment/reader/PathFinder.js
+++ b/map-fragment/reader/PathFinder.js
@@ -1,26 +1,83 @@
 const { MapReader } = require("./MapReader");
-const Graph = require("node-dijkstra")
+const Graph = require("node-dijkstra");
 
 class PathFinder {
-
     /**
-     * 
-     * @param {MapReader} reader 
+     * @param {MapReader} reader
      */
     constructor(reader) {
-        this.route = new Graph();
-        reader.getAreas().forEach(area => area.rooms.forEach(room => {
-            let exits = Object.values(room.exits).concat(Object.values(room.specialExits)).map(item => [item, room.weight ?? 1]);
-            this.route.addNode(room.id.toString(), Object.fromEntries(exits))
-        }))
+        this.reader = reader;
+        this.areaGraphs = new Map();
+        this.pathCache = new Map();
     }
 
+    /**
+     * Build and cache a graph for a specific area.
+     * @param {number} areaId
+     * @returns {Graph}
+     */
+    _buildAreaGraph(areaId) {
+        const graph = new Graph();
+        const area = this.reader.getAreaProperties(areaId);
+        if (area?.rooms) {
+            area.rooms.forEach((room) => {
+                const exits = Object.values(room.exits)
+                    .concat(Object.values(room.specialExits))
+                    .map((id) => [id, room.weight ?? 1]);
+                graph.addNode(room.id.toString(), Object.fromEntries(exits));
+            });
+        }
+        this.areaGraphs.set(areaId, graph);
+        return graph;
+    }
+
+    /**
+     * Lazily build a graph for the whole map.
+     * @returns {Graph}
+     */
+    _buildGlobalGraph() {
+        const graph = new Graph();
+        this.reader.getAreas().forEach((area) =>
+            area.rooms.forEach((room) => {
+                const exits = Object.values(room.exits)
+                    .concat(Object.values(room.specialExits))
+                    .map((id) => [id, room.weight ?? 1]);
+                graph.addNode(room.id.toString(), Object.fromEntries(exits));
+            })
+        );
+        this.globalGraph = graph;
+        return graph;
+    }
+
+    /**
+     * Find a path between two rooms. Results are cached.
+     * @param {number} from
+     * @param {number} to
+     * @returns {Array<string>|null}
+     */
     path(from, to) {
-        return this.route.path(from.toString(), to.toString())
-    }
+        const cacheKey = `${from}-${to}`;
+        if (this.pathCache.has(cacheKey)) {
+            return this.pathCache.get(cacheKey);
+        }
 
+        const fromRoom = this.reader.getRoomById(from);
+        const toRoom = this.reader.getRoomById(to);
+
+        let graph;
+        if (fromRoom && toRoom && fromRoom.areaId === toRoom.areaId) {
+            const areaId = fromRoom.areaId;
+            graph = this.areaGraphs.get(areaId) ?? this._buildAreaGraph(areaId);
+        } else {
+            graph = this.globalGraph ?? this._buildGlobalGraph();
+        }
+
+        const result = graph.path(from.toString(), to.toString());
+        this.pathCache.set(cacheKey, result);
+        return result;
+    }
 }
 
 module.exports = {
-    PathFinder
-}
+    PathFinder,
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
         "paper-jsdom": "^0.12.17"
     },
     "main": "./exports.js",
+    "scripts": {
+        "test": "node --test"
+    },
     "devDependencies": {
         "babelify": "^10.0.0",
         "@babel/core": "^7.20.12"

--- a/test/pathfinder.test.js
+++ b/test/pathfinder.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('assert');
+const { PathFinder } = require('../map-fragment/reader/PathFinder');
+const { MapReader } = require('../map-fragment/reader/MapReader');
+
+test('finds path within an area and caches result', () => {
+  const mapData = [
+    {
+      areaId: 1,
+      areaName: 'Area1',
+      rooms: [
+        { id: 1, exits: { 2: 2 }, specialExits: {}, weight: 1, x: 0, y: 0, z: 0 },
+        { id: 2, exits: { 1: 1 }, specialExits: {}, weight: 1, x: 1, y: 0, z: 0 }
+      ],
+      labels: []
+    }
+  ];
+  const reader = new MapReader(mapData, []);
+  const pf = new PathFinder(reader);
+  const first = pf.path(1, 2);
+  assert.deepStrictEqual(first, ['1', '2']);
+  assert.strictEqual(pf.pathCache.size, 1);
+  const second = pf.path(1, 2);
+  assert.deepStrictEqual(second, ['1', '2']);
+  assert.strictEqual(pf.pathCache.size, 1);
+  assert.ok(pf.areaGraphs.has(1));
+  assert.strictEqual(pf.globalGraph, undefined);
+});
+
+test('falls back to global graph for cross-area paths', () => {
+  const mapData = [
+    {
+      areaId: 1,
+      areaName: 'Area1',
+      rooms: [
+        { id: 1, exits: { 2: 2 }, specialExits: {}, weight: 1, x: 0, y: 0, z: 0 },
+        { id: 2, exits: { 1: 1, 3: 3 }, specialExits: {}, weight: 1, x: 1, y: 0, z: 0 }
+      ],
+      labels: []
+    },
+    {
+      areaId: 2,
+      areaName: 'Area2',
+      rooms: [
+        { id: 3, exits: { 2: 2, 4: 4 }, specialExits: {}, weight: 1, x: 2, y: 0, z: 0 },
+        { id: 4, exits: { 3: 3 }, specialExits: {}, weight: 1, x: 3, y: 0, z: 0 }
+      ],
+      labels: []
+    }
+  ];
+  const reader = new MapReader(mapData, []);
+  const pf = new PathFinder(reader);
+  const path = pf.path(1, 4);
+  assert.deepStrictEqual(path, ['1', '2', '3', '4']);
+  assert.ok(pf.globalGraph);
+  assert.strictEqual(pf.areaGraphs.size, 0);
+});


### PR DESCRIPTION
## Summary
- optimize pathfinding by caching per-area graphs and results
- document PathFinder behavior and caching strategy
- add unit tests covering cached area paths and global fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e1f67534832a81623b0523dacf60